### PR TITLE
LHS seeding in the constructor (#397)

### DIFF
--- a/smt/sampling_methods/full_factorial.py
+++ b/smt/sampling_methods/full_factorial.py
@@ -11,7 +11,7 @@ from smt.sampling_methods.sampling_method import ScaledSamplingMethod
 
 
 class FullFactorial(ScaledSamplingMethod):
-    def _initialize(self):
+    def _initialize(self, **kwargs):
         self.options.declare(
             "weights",
             values=None,

--- a/smt/sampling_methods/sampling_method.py
+++ b/smt/sampling_methods/sampling_method.py
@@ -35,12 +35,18 @@ class SamplingMethod(metaclass=ABCMeta):
             types=np.ndarray,
             desc="The interval of the domain in each dimension with shape nx x 2 (required)",
         )
-        self._initialize()
+        self._initialize(**kwargs)
         self.options.update(kwargs)
 
-    def _initialize(self) -> None:
+    def _initialize(self, **kwargs) -> None:
         """
-        Implemented by sampling methods to declare options (optional).
+        Implemented by sampling methods to declare options
+        and/or use these optional values for initialization (optional)
+
+        Parameters
+        ----------
+        **kwargs : named arguments passed by the user
+            Set of options that can be optionally set
 
         Examples
         --------

--- a/smt/sampling_methods/tests/test_lhs.py
+++ b/smt/sampling_methods/tests/test_lhs.py
@@ -16,19 +16,21 @@ class Test(unittest.TestCase):
     def test_random_state(self):
         xlimits = np.array([[0.0, 4.0], [0.0, 3.0]])
         num = 10
-        sampling = LHS(xlimits=xlimits, criterion="ese")
-        doe1 = sampling(num)
-        sampling = LHS(xlimits=xlimits, criterion="ese")
-        doe2 = sampling(num)
-        self.assertFalse(np.allclose(doe1, doe2))
-
         sampling = LHS(xlimits=xlimits, criterion="ese", random_state=42)
         doe1 = sampling(num)
+        doe2 = sampling(num)
+
+        # Should not generate the same doe
+        self.assertFalse(np.allclose(doe1, doe2))
+
+        # Another LHS with same initialization should generate the same sequence of does
         sampling = LHS(
             xlimits=xlimits, criterion="ese", random_state=np.random.RandomState(42)
         )
-        doe2 = sampling(num)
-        self.assertTrue(np.allclose(doe1, doe2))
+        doe3 = sampling(num)
+        doe4 = sampling(num)
+        self.assertTrue(np.allclose(doe1, doe3))
+        self.assertTrue(np.allclose(doe2, doe4))
 
     def test_expand_lhs(self):
         import numpy as np


### PR DESCRIPTION
* Initialize random seed once in LHS constructor

Have to change _initialize signature to pass
option values as options are not set yet.
Not used by other sampling methods so far.

* Adjust surrogate tests tolerances due to new LHS seeding